### PR TITLE
Enable background linting.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -25,7 +25,7 @@ class Yamllint(PythonLinter):
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): \[((?P<warning>warning)|(?P<error>error))\] (?P<message>.+)'
     )
-    tempfile_suffix = '-'
+    tempfile_suffix = 'yaml'
     error_stream = util.STREAM_STDOUT
     word_re = r'^(".*?"|[-\w]+)'
     module = 'yamllint'


### PR DESCRIPTION
Changed the tempfile_suffix to yaml. So now the linter will operate
on a tmpfile rather than waiting for the actual file to get saved.