### PR TITLE
Allow using custom config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,33 @@ Before using this plugin, you must ensure that `yamllint` is installed on your s
 
 **Note:** This plugin requires `yamllint` 1.9 or later.
 
-### Linter configuration
+### Linter configuration - basic
 In order for `yamllint` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.
 
 Once you have installed and configured `yamllint`, you can proceed to install the SublimeLinter-contrib-yamllint plugin if it is not yet installed.
+
+### Linter configuration - overriding
+
+
+Notice that by default yamllint tries to load .yamllint file from the working directory, if exists. That's why sometimes it is better to load specific
+config based on the project.
+
+Overriding plugin defaults can be done by setting .sublime-project `settings` section, for example below will use `.yamllint` file from the root of the project path:
+
+```json
+    "settings":
+    {
+        "SublimeLinter.linters.yamllint.c": 
+        [
+            "${project_path}/.yamllint"
+        ]
+    }
+
+```
+
+Of course you can also hard-code here some path if you really need to.
+
+For more see [SublimeLinter docs](https://sublimelinter.readthedocs.io/en/stable/settings.html#settings-expansion).
 
 ### Plugin installation
 Please use [Package Control][pc] to install the linter plugin. This will ensure that the plugin will be updated when new versions are available. If you want to install from source so you can modify the source code, you probably know what you are doing so we won’t cover that here.
@@ -46,6 +69,7 @@ rules:
     max: 600
 ```
 
+Also if you use per-project override then it is strongly encouraged to set `.yamllint` file in the root of the project path.
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/linter.py
+++ b/linter.py
@@ -10,17 +10,21 @@
 
 """This module exports the Yamllint plugin class."""
 
-from SublimeLinter.lint import PythonLinter, util
+from SublimeLinter.lint import Linter, util
 
 
-class Yamllint(PythonLinter):
+class Yamllint(Linter):
     """Provides an interface to yamllint."""
 
     defaults = {
-        'selector': 'source.yaml'
+        'selector': 'source.yaml',
+        'args': '-f parsable',
+        '-c': '',  # CONFIG_FILE
+        '-d': '',  # CONFIG_DATA, but this is deprecated option
     }
-    cmd = ('yamllint', '-f', 'parsable', '*')
-    executable = None
+    inline_overrides = ['c', 'd']
+
+    cmd = ('yamllint', '${args}', '${file}')
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 1.9'


### PR DESCRIPTION
Add option to use .yamllint from project path.
This is especially useful in cases when you have different standards
per project (for example ansible vs kubernetes).