### PR TITLE
Always add parsable format to command options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.3"
+  - "3.6"
 # command to install dependencies
 install:
   - pip install flake8

--- a/linter.py
+++ b/linter.py
@@ -18,12 +18,11 @@ class Yamllint(Linter):
 
     defaults = {
         'selector': 'source.yaml',
-        'args': '-f parsable',
         '-c': '',  # CONFIG_FILE
         '-d': '',  # CONFIG_DATA, but this is deprecated option
     }
 
-    cmd = ('yamllint', '${args}', '${file}')
+    cmd = ('yamllint', '--format', 'parsable', '${args}', '${file}')
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+): \[((?P<warning>warning)|(?P<error>error))\] (?P<message>.+)'
     )


### PR DESCRIPTION
When adding extra arguments to the `yamllint` command, it removes the `-f parsable` option, which prevents any of the linting errors from being reported in Sublime Text.

Move the `--format parsable` option to the default `cmd` so it is always present in the final command.

I encountered this myself and found [this issue](https://github.com/SublimeLinter/SublimeLinter/issues/1648) which pointed me to the solution.