### PR TITLE
Match code

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -24,7 +24,7 @@ class Yamllint(Linter):
 
     cmd = ('yamllint', '--format', 'parsable', '${args}', '${temp_file}')
     regex = (
-        r'^.+?:(?P<line>\d+):(?P<col>\d+): \[(?P<error_type>[^\]]+)\] (?P<message>.+)'
+        r'^.+?:(?P<line>\d+):(?P<col>\d+): \[(?P<error_type>[^\]]+)\] (?P<message>.+?)(?:\s+\((?P<code>\S+)\))?$'
     )
     tempfile_suffix = 'yaml'
     error_stream = util.STREAM_STDOUT


### PR DESCRIPTION
With the newly added annotations feature for SublimeLinter, I added a template that would render the code of the lint result inline, but unfortunatley the yamllint linter didn't match that. This PR addresses that.

**Preview**
```
        {
            "types": ["warning"],
            "scope": "region.yellowish markup.warning.sublime_linter",
            "annotation": "{linter}:{code}",
            "phantom": "",
        },
```

![2022-10-20_20-12-02](https://user-images.githubusercontent.com/931051/197026048-a8b451b6-6c22-46a1-90dc-34108b132425.png)

---

I am participating in [Hacktoberfest](https://hacktoberfest.com/). If you want to support this event and liked my contribution, please consider adding a `hacktoberfest-accepted` label to this pull request if you have not configured your repository to take part in it. If you have, please try to approve or merge the pull request before the end of October (or use the label if you believe you will not be able to fully review it but consider the contribution genuine).